### PR TITLE
timezone + household size

### DIFF
--- a/app/customer-questions/[[...customer-questions]]/page.tsx
+++ b/app/customer-questions/[[...customer-questions]]/page.tsx
@@ -560,7 +560,9 @@ const DemographicsSurvey: React.FC = () => {
         if (responses.changes == "yes") {
           setCurrentStep('name');
         } else {
-          router.push('/saved-thank-you');
+          handleSubmit();
+          setCurrentStep('confirmation');
+          // router.push('/saved-thank-you');
         }
         break;
       case 'name':
@@ -652,9 +654,9 @@ const DemographicsSurvey: React.FC = () => {
                 phoneNumber: responses.phoneNumber,
                 takeCount: (prevRecord.takeCount || 0) + (responses.receive ? 1 : 0),
                 donateCount: (prevRecord.donateCount || 0) + (responses.donate ? 1 : 0),
-                name: `${responses.name.firstName} ${responses.name.lastName}`,
-                address: `${responses.address.line1}, ${responses.address.city}, ${responses.address.state} ${responses.address.zip}`,
-                householdSize: responses.householdSize,
+                name: responses.changes == "yes" ? `${responses.name.firstName} ${responses.name.lastName}` : prevRecord.name,
+                address: responses.changes == "yes" ? `${responses.address.line1}, ${responses.address.city}, ${responses.address.state} ${responses.address.zip}` : prevRecord.address,
+                householdSize: responses.changes == "yes" ? responses.householdSize : prevRecord.householdSize,
                 lastVisitDate: responses.receive ? new Date().toISOString() : prevRecord.lastVisitDate,
                 previousVisitDates: Array.isArray(prevRecord.previousVisitDates) 
                   ? [...prevRecord.previousVisitDates, currentDate] 

--- a/app/demographics/[[...demographics]]/page.tsx
+++ b/app/demographics/[[...demographics]]/page.tsx
@@ -34,7 +34,7 @@ function getDemographics() {
         .then((demographicsData) => {
 
                 const rearrangedData = demographicsData.map((record: DemographicsRecord) => {
-                    const arr = [new Date(record.lastVisitDate).toLocaleString("en-US", {timeZone: "America/New_York"}).split('T')[0], record.phoneNumber, record.name, record.address, record.householdSize == 11 ? "10+" : record.householdSize.toString(), record.takeCount, record.donateCount];
+                    const arr = [new Date(record.lastVisitDate).toLocaleString("en-US", {timeZone: "America/New_York"}).split('T')[0], record.phoneNumber, record.name, record.address, record.householdSize, record.takeCount, record.donateCount];
                     return arr;
                 });
 

--- a/app/demographics/[[...demographics]]/page.tsx
+++ b/app/demographics/[[...demographics]]/page.tsx
@@ -34,7 +34,7 @@ function getDemographics() {
         .then((demographicsData) => {
 
                 const rearrangedData = demographicsData.map((record: DemographicsRecord) => {
-                    const arr = [record.lastVisitDate.split('T')[0], record.phoneNumber, record.name, record.address, record.householdSize, record.takeCount, record.donateCount];
+                    const arr = [new Date(record.lastVisitDate).toLocaleString("en-US", {timeZone: "America/New_York"}).split('T')[0], record.phoneNumber, record.name, record.address, record.householdSize == 11 ? "10+" : record.householdSize.toString(), record.takeCount, record.donateCount];
                     return arr;
                 });
 


### PR DESCRIPTION
- last visit date is shown as "date time" instead of just date, which i think is more useful but let me know and i can switch it back (like in case they wanna see the most popular time of a day to see when they should more frequently restock)
- ~household size done!~ reverted in second push
- when "no" was selected for "changes", form wasn't being submitted. fixed!