### PR TITLE
Bug fix: download null inventory history

### DIFF
--- a/app/api/inventory/route.ts
+++ b/app/api/inventory/route.ts
@@ -13,8 +13,21 @@ async function createInventoryItem(data: {
   lastUpdated: Date;
   history?: Prisma.InputJsonValue;
 }) {
+  
+  const newHistory = 
+      {
+        itemName: data.itemName,
+        categoryName: data.categoryName,
+        units: data.units,
+        action: 'add',
+        quantityChanged: data.quantity,
+        date: data.lastUpdated,
+      };
+
   return await prisma.inventory.create({ 
-    data: { ...data }
+    data: { ...data,
+      history: newHistory as Prisma.InputJsonValue
+    }
   });
 }
 

--- a/app/api/inventory/route.ts
+++ b/app/api/inventory/route.ts
@@ -13,19 +13,37 @@ async function createInventoryItem(data: {
   lastUpdated: Date;
   history?: Prisma.InputJsonValue;
 }) {
-  
-  const newHistory = 
-      {
-        itemName: data.itemName,
-        categoryName: data.categoryName,
-        units: data.units,
-        action: 'add',
-        quantityChanged: data.quantity,
-        date: data.lastUpdated,
-      };
+  const { itemName, units } = data;
 
-  return await prisma.inventory.create({ 
-    data: { ...data,
+  const historyKey = `${itemName}_${units}`;
+
+  // Ensure history is an object (if undefined, default to an empty object)
+  const initialHistory: Record<string, unknown> = data.history && typeof data.history === "object"
+    ? (data.history as Record<string, unknown>)
+    : {};
+
+  // Initialize history entry
+  const newHistoryEntry = {
+    itemName: data.itemName,
+    categoryName: data.categoryName,
+    units: data.units,
+    action: "add",
+    quantityChanged: data.quantity,
+    date: data.lastUpdated,
+  };
+
+  // Create a structured history object
+  const newHistory = {
+    ...initialHistory,
+    [historyKey]: [
+      ...(initialHistory[historyKey] as Array<typeof newHistoryEntry> || []),
+      newHistoryEntry
+    ]
+  };
+
+  return await prisma.inventory.create({
+    data: {
+      ...data,
       history: newHistory as Prisma.InputJsonValue
     }
   });


### PR DESCRIPTION
Bug fix: download null inventory history

Names: Zoya & Sofia

Date: 03/13/25

How long did this ticket take you? 20 mins

Description: We extended the API POST for inventory so that history is not null when an item is first added to.

Testing (before and after screenshots):
<img width="1509" alt="Screenshot 2025-03-13 at 4 44 48 PM" src="https://github.com/user-attachments/assets/ddae69d9-23a1-4fe6-b78f-53f217e3a796" />
<img width="964" alt="Screenshot 2025-03-13 at 4 45 03 PM" src="https://github.com/user-attachments/assets/2afe3910-d67b-48ac-86cd-560cb5dbe5e6" />

Takeaways: 
- Learned how to make a history item & change the data that is passed into the API POST call