### PR TITLE
Internal View: Capacity Meter BE #144

### DIFF
--- a/app/demographics/[[...demographics]]/page.tsx
+++ b/app/demographics/[[...demographics]]/page.tsx
@@ -9,6 +9,7 @@ import ProgressBar from "@app/components/ProgressBar";
 import crossIcon from '@app/images/cross-svgrepo-com.svg';
 import Image from "next/image";
 import { MdDeleteOutline } from "react-icons/md";
+import { $Enums } from "@prisma/client";
 
 // Define a type for the structure of each record returned by the API
 interface DemographicsRecord {
@@ -139,10 +140,24 @@ const InternalViewDemographicsPage: React.FC = () => {
     setShowModal(false)
   };
 
-  const handleDelete = () => {
-    // TODO I don't know what to do :)
-    console.log("in handle delete")
-  }
+const handleDelete = async () => {
+    try {
+      for (const row of transformedDemographics) {
+        const phoneNumber = row[1];
+        const response = await fetch("../api/demographics", {
+          method: "DELETE",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ phoneNumber }),
+        });
+        if (!response.ok) {
+          console.error('Error Deleting Item, ${response.status}');
+        }
+      }
+      window.location.reload();
+    } catch (e) {
+      console.log("Error Deleting Category Items:", e);
+    }
+  };
 
   // States and logic for the storage modal remain unchanged
   const [showStorageModal, setShowStorageModal] = useState(false);

--- a/app/demographics/[[...demographics]]/page.tsx
+++ b/app/demographics/[[...demographics]]/page.tsx
@@ -9,7 +9,6 @@ import ProgressBar from "@app/components/ProgressBar";
 import crossIcon from '@app/images/cross-svgrepo-com.svg';
 import Image from "next/image";
 import { MdDeleteOutline } from "react-icons/md";
-import { $Enums } from "@prisma/client";
 
 // Define a type for the structure of each record returned by the API
 interface DemographicsRecord {

--- a/app/demographics/[[...demographics]]/page.tsx
+++ b/app/demographics/[[...demographics]]/page.tsx
@@ -139,6 +139,11 @@ const InternalViewDemographicsPage: React.FC = () => {
     setShowModal(false)
   };
 
+  const handleDelete = () => {
+    // TODO I don't know what to do :)
+    console.log("in handle delete")
+  }
+
   // States and logic for the storage modal remain unchanged
   const [showStorageModal, setShowStorageModal] = useState(false);
   const [showStorageCancel, setShowStorageCancel] = useState(false);
@@ -261,7 +266,7 @@ const InternalViewDemographicsPage: React.FC = () => {
                           <div>
                             <button
                               className="flex items-center text-white bg-red hover:bg-dark-red font-serif w-[100px] h-[40px] rounded-[8px] border-[1px] text-[20px] justify-center"
-                              onClick={() => console.log("just pressed delete")}
+                              onClick={() => handleDelete()}
                             >
                               Delete
                             </button>

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,20 +37,3 @@ model categories {
   @@id([itemName, name])
 }
 
-model users {
-  firstName   String
-  lastName    String
-  pronouns    String
-  username    String @id
-  email       String
-  role        Role
-  phoneNumber String
-  password    String
-}
-
-enum Role {
-  admin
-  staff
-  volunteer
-  customer
-}


### PR DESCRIPTION
Title: Internal View: Capacity Meter BE #144

Names: Emily, Alex

Date: 3/25/2025

How long did this ticket take you? 1.5 hours

Description: Deleted all rows in spreadsheet for demographics when user on capacity meter presses delete all categories in the modal. 

Testing (before and after screenshots): Takeaways: Checked Neon database, manually added information in demographics and deleting after to ensure that everything actually deleted. 