### PR TITLE
quantity updates without reloading page

### DIFF
--- a/app/components/InventorySpreadsheet.tsx
+++ b/app/components/InventorySpreadsheet.tsx
@@ -185,7 +185,8 @@ export const InventorySpreadsheet: React.FC<InventorySpreadsheetProps> = ({ inve
   
           console.log(`Deleted inventory item: ${itemName} (${units})`);
           closeDeleteModal();
-          refreshPage();
+          setSortedItems(sortedItems.filter((item) => (item[0] != itemName) && (item[3] != units)))
+          
       } catch (error) {
           console.error("Inventory delete failed:", error);
       }

--- a/app/components/InventorySpreadsheet.tsx
+++ b/app/components/InventorySpreadsheet.tsx
@@ -38,6 +38,7 @@ export const InventorySpreadsheet: React.FC<InventorySpreadsheetProps> = ({ inve
     const [itemName, setItemName] = useState<string | null>(null);
     const [units, setUnits] = useState<string | null>(null);
     const [currCategoryName, setCurrCategoryName] = useState<string | null>(null);
+    const [currentQuantity, setCurrentQuantity] = useState<number>(0);
 
     const closeQuantityModal = (): void => {
         setShowQuantityModal(false);
@@ -46,11 +47,12 @@ export const InventorySpreadsheet: React.FC<InventorySpreadsheetProps> = ({ inve
         setCurrCategoryName(null);
     };
 
-    const openQuantityModal = (itemName: string, units: string, category: string): void => {
-        setShowQuantityModal(true);
-        setItemName(itemName);
-        setUnits(units);
-        setCurrCategoryName(category);
+    const openQuantityModal = (itemName: string, units: string, category: string, quantity: number): void => {
+      setShowQuantityModal(true);
+      setItemName(itemName);
+      setUnits(units);
+      setCurrCategoryName(category);
+      setCurrentQuantity(quantity);
     };
 
     const closeDeleteModal = (): void => {
@@ -304,7 +306,8 @@ export const InventorySpreadsheet: React.FC<InventorySpreadsheetProps> = ({ inve
                           openQuantityModal(
                             String(sortedItems[index][0]),
                             String(sortedItems[index][3]),
-                            String(sortedItems[index][1])
+                            String(sortedItems[index][1]),
+                            Number(sortedItems[index][2])
                           )
                         }
                       />
@@ -324,6 +327,7 @@ export const InventorySpreadsheet: React.FC<InventorySpreadsheetProps> = ({ inve
                               closeModal={closeQuantityModal}
                               handleUpdate={handleUpdateQuantity}
                               categoryName={String(currCategoryName)}
+                              currentQuantity={currentQuantity}
                           />
                       )}
                       <MdOutlineFileDownload

--- a/app/components/InventorySpreadsheet.tsx
+++ b/app/components/InventorySpreadsheet.tsx
@@ -138,8 +138,26 @@ export const InventorySpreadsheet: React.FC<InventorySpreadsheetProps> = ({ inve
             if (!response.ok) {
                 throw new Error("Error updating inventory data.");
             }
+            
+              setSortedItems(prevItems =>
+                prevItems.map(row => {
+                    const nameMatch = row[0] === itemName;
+                    const unitMatch = row[3] === units;
+                    const categoryMatch = row[1] === categoryName;
+    
+                    if (nameMatch && unitMatch && categoryMatch) {
+                        const updatedRow = [...row];
+                        updatedRow[2] = Number(quantityChange);
+                        updatedRow[4] = formatDate(new Date());
+                        return updatedRow;
+                    }
+                    return row;
+                })
+            );
+            
             closeQuantityModal();
-            refreshPage();
+            // refreshPage();
+            
             console.log("Updated successfully!");
           
         } catch (error) {
@@ -263,7 +281,7 @@ export const InventorySpreadsheet: React.FC<InventorySpreadsheetProps> = ({ inve
               </tr>
             </thead>
             <tbody className="bg-zinc-75 border-collapse border-zinc-400 font-crimson">
-              {sortedItems.map((item, index) => (
+              { sortedItems.map((item, index) => (
                 <tr key={index} className="py-2">
                   {item.map((data, subIndex) => (
                     <td

--- a/app/components/QuantityModal.tsx
+++ b/app/components/QuantityModal.tsx
@@ -8,11 +8,11 @@ interface QuantityProps {
     categoryName: string; 
     closeModal: () => void; 
     handleUpdate: (itemName: string, units: string, quantityChange: number, categoryName: string) => void; 
-
+    currentQuantity: number;
 }
 
-const QuantityModal: React.FC<QuantityProps> = ({ itemName, units, categoryName, closeModal, handleUpdate}) => {
-    const [quantityChange, setQuantityChange] = useState(0);
+const QuantityModal: React.FC<QuantityProps> = ({ itemName, units, categoryName, closeModal, handleUpdate, currentQuantity}) => {
+    const [quantityChange, setQuantityChange] = useState(currentQuantity);
     const [showQuantityError, setShowQuantityError] = useState(false);
 
     const handleSave = () => {
@@ -31,6 +31,7 @@ const QuantityModal: React.FC<QuantityProps> = ({ itemName, units, categoryName,
                         <div className="flex w-full justify-center items-center pb-[30px]">
                             <input
                                 type="number"
+                                value={quantityChange}
                                 onChange={(e) => setQuantityChange(parseInt(e.target.value, 10) || 0)}
                                 className="flex w-[242px] h-[50px] bg-inherit rounded-[13px] border-[3px] border-[#E1E1E1] justify-center"
                             />


### PR DESCRIPTION
Title: Quantites update & row deletes without refresh

Names: Charlie Koenig & Amanda Wu

Date: 3/26/25

How long did this ticket take you? 30 min

Description: 
- When updating the quantity for an existing item in the inventory the inventory spreadsheet updates the FE quantity without refreshing the page
- When deleting a row in the inventory spreadsheet the row is visually deleted on FE without refresh

Testing (before and after screenshots): 

<img width="1310" alt="Screenshot 2025-03-26 at 8 48 52 PM" src="https://github.com/user-attachments/assets/d065327a-b599-4043-8689-c9f6bc5328b5" />
<img width="1307" alt="Screenshot 2025-03-26 at 8 49 02 PM" src="https://github.com/user-attachments/assets/5c1190f5-7b62-4399-91f9-332a8ac23d42" />
<img width="1307" alt="Screenshot 2025-03-26 at 8 49 12 PM" src="https://github.com/user-attachments/assets/d6ba5b72-fc57-4e41-a046-05939809ba8e" />

Takeaways:
- learned to map through spreadsheet to update FE instead of refetching