### PR TITLE
Role should not be editable when editing own profile

### DIFF
--- a/app/components/ProfileView.tsx
+++ b/app/components/ProfileView.tsx
@@ -204,15 +204,13 @@ const ProfileView : React.FC<ProfileViewProps> = ({ visible, mode, profileData, 
                     <label className="block font-crimson text-[20px] mb-1">
                         Role <span className="text-red">*</span>
                     </label>
-                    <select
+                    <input
                         value={profileData.role}
                         onChange={(e) => handleChangeMade(e, "role")}
                         className="pl-3 font-crimson text-[20px] focus:outline-none border-2 border-[#E1E1E1] rounded-xl w-[452px] h-[50px]"
-                        disabled={isView}
+                        disabled={isView || isEdit}
                     >
-                        <option value="Staff">Staff</option>
-                        <option value="Admin">Admin</option>
-                    </select>
+                    </input>
                 </div>
             </div>
 


### PR DESCRIPTION
Names: Ella & Sofia

Date: 03/30/25

How long did this ticket take you? 10 mins

Description: We made the role not be editable in the edit profile page.

Testing (before and after screenshots):
<img width="1511" alt="Screenshot 2025-03-30 at 8 40 37 PM" src="https://github.com/user-attachments/assets/d1dd6c2b-5845-4e4b-a8b8-62632567e5c3" />

Takeaways: 
- Learned the difference between input vs select