### PR TITLE
forgot password flow keeps your input when you go back

### DIFF
--- a/app/login/[[...login]]/page.tsx
+++ b/app/login/[[...login]]/page.tsx
@@ -71,7 +71,6 @@ const LoginPage: React.FC = () => {
   const [emptyPasswordError, setEmptyPasswordError] = useState(false)
 
   const handleGoBack = () => {
-    console.log("going back", username, password)
     setErrorMsg('\u00A0');
     if (showTypeEmail) {
       setShowTypeEmail(false);

--- a/app/login/[[...login]]/page.tsx
+++ b/app/login/[[...login]]/page.tsx
@@ -71,6 +71,7 @@ const LoginPage: React.FC = () => {
   const [emptyPasswordError, setEmptyPasswordError] = useState(false)
 
   const handleGoBack = () => {
+    console.log("going back", username, password)
     setErrorMsg('\u00A0');
     if (showTypeEmail) {
       setShowTypeEmail(false);
@@ -303,6 +304,7 @@ const LoginPage: React.FC = () => {
                 type="text"
                 id="username"
                 className="w-full bg-gray bg-opacity-30 border-2 rounded-md border-light-green text-white focus:border-2 focus:rounded-md focus:border-dark-green focus:ring-0 placeholder-neutral-400"
+                defaultValue={username || ""}
                 onChange={(e) => setUsername(e.target.value)}
                 placeholder="Username"
                 required
@@ -323,6 +325,7 @@ const LoginPage: React.FC = () => {
                 id="password"
                 type={showPassword ? "text" : "password"}
                 className="w-full bg-gray bg-opacity-30 border-2 rounded-md border-light-green text-white focus:border-2 focus:rounded-md focus:border-dark-green focus:ring-0 placeholder-neutral-400"
+                defaultValue={password || ""}
                 onChange={(e) => setPassword(e.target.value)}
                 placeholder="Password"
                 required
@@ -383,6 +386,7 @@ const LoginPage: React.FC = () => {
                   id="password-reset"
                   className="w-full bg-gray bg-opacity-30 text-white border-2 rounded-md border-light-green focus:border-2 focus:rounded-md focus:border-dark-green focus:ring-0 placeholder-neutral-400"
                   placeholder="Email"
+                  defaultValue={email || ""}
                   onChange={(e) => setEmail(e.target.value)}
                   required
                 />    
@@ -482,6 +486,7 @@ const LoginPage: React.FC = () => {
                 <label className="block mb-2 text-2xl text-white">Reset Code</label>
                 <input
                   type="text"
+
                   id="reset-code"
                   className="w-full bg-gray bg-opacity-30 border-2 text-white rounded-md border-light-green focus:border-2 focus:rounded-md focus:border-dark-green focus:ring-0 placeholder-neutral-400"
                   placeholder="Reset Code"


### PR DESCRIPTION
Title: Forgot password flow retaining prev info

Names: Daniel Jakab, Vanessa Rose

Date: 3/30/25

How long did this ticket take you? 20 minutes

Description: Input is saved when back button is pressed in forgot password flow

Testing (before 
![image_720](https://github.com/user-attachments/assets/8275352e-5230-4492-8802-9c4b0f50dc5e)
and after screenshots):
![image_720](https://github.com/user-attachments/assets/ff03b272-f2a5-451d-94f0-80640280e3c2)
![image_720](https://github.com/user-attachments/assets/482377b5-ed64-4d1e-9b59-efb8feaf6e3d)
![image_720](https://github.com/user-attachments/assets/6336f9b6-f106-4ef4-b014-e03f6ca28566)
![image_720](https://github.com/user-attachments/assets/1d3001ba-0e75-41a2-8812-c5b2fbdf0221)

Takeaways: defaultValue property for input boxes