### PR TITLE
172 frontend fixed repitition of unit boxes label

### DIFF
--- a/app/components/UnitBoxes.tsx
+++ b/app/components/UnitBoxes.tsx
@@ -4,12 +4,14 @@ import Image, { StaticImageData } from 'next/image';
 interface AddUnitBoxProps {
   value: string;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  showLabel: boolean;
 }
 
-function AddUnitBox({ value, onChange }: AddUnitBoxProps) {
+function AddUnitBox({ value, onChange, showLabel }: AddUnitBoxProps) {
   return (
     <div className='flex ml-[5%] mb-2'>
-      <div className="font-crimson text-[28px] w-24 items-center">Units</div>
+      {showLabel && <div className="font-crimson text-[28px] w-24 items-center">Units</div>}
+      {!showLabel && <div className="font-crimson text-[28px] w-24 items-center"></div>}
       <input
         type="text"
         value={value}
@@ -60,6 +62,7 @@ const UnitBoxes: React.FC<UnitBoxesProps> = ({ icon, onUnitsChange, initialUnits
           <AddUnitBox 
             value={unitValues[index] || ""} 
             onChange={(e) => handleInputChange(index, e.target.value)} 
+            showLabel={index === 0}
           />
           {index === unitCount - 1 && unitCount < 5 && (
             <button onClick={addUnit} className='ml-2'>


### PR DESCRIPTION
Title: Removing repeated Units Label in unit boxes

Names:  Emily and Zoya

Date: 30/3/2025

How long did this ticket take you? 30 mins

Description:
Added a boolean to check if this is the first 'unit box', and to include the label if it is otherwise just add padding. 

Testing (before and after screenshots):
<img width="442" alt="Screenshot 2025-03-30 at 9 03 51 PM" src="https://github.com/user-attachments/assets/75eb8930-d380-40b4-8bbd-dbf88a65e7c5" />

Takeaways: :)