### PR TITLE
Chart for visits by hour

### DIFF
--- a/app/components/HourlyVisitsChart.tsx
+++ b/app/components/HourlyVisitsChart.tsx
@@ -26,10 +26,11 @@ ChartJS.register(
 interface HourlyVisitsChartProps {
     lastWeek: number[];
     lastSixtyDays: number[];
+    viewMode: 'average' | 'raw';
 }
 
 
-const HourlyVisitsChart: React.FC<HourlyVisitsChartProps> = ({ lastWeek, lastSixtyDays }) => {
+const HourlyVisitsChart: React.FC<HourlyVisitsChartProps> = ({ lastWeek, lastSixtyDays, viewMode }) => {
     const labels = Array.from({ length: 24 }, (_, i) => `${i}:00`);
 
     const data = {
@@ -63,28 +64,31 @@ const HourlyVisitsChart: React.FC<HourlyVisitsChartProps> = ({ lastWeek, lastSix
                 display: true,
                 position: 'top' as const,
                 labels: {
-                    boxWidth: 0,
-                    generateLabels: function(chart: any) {
-                        return chart.data.datasets.map((dataset: any, i: number) => {
-                            const meta = chart.getDatasetMeta(i);
-                            const fadedColor = 'rgba(128, 128, 128, 0.5)';
-                            const visibleColor = (i === 0)
-                            ? '#24593D'
-                            : 'rgb(137, 175, 132)';
-
-                            return {
-                                datasetIndex: i,
-                                text: (i === 0 ? dataset.label + '          ' : dataset.label),
-                                fillStyle: dataset.backgroundColor,
-                                hidden: meta.hidden,
-                                fontColor: meta.hidden ? fadedColor : visibleColor,
-                                textDecoration: 'none',
-                                fontStyle: 'normal',
-                                strokeStyle: null,
-                            };
-                        });
-                    },
-                },
+                    usePointStyle: true,
+                    generateLabels: function (chart: any) {
+                      return chart.data.datasets.map((dataset: any, i: number) => {
+                        const meta = chart.getDatasetMeta(i);
+                        const isHidden = meta.hidden;
+                  
+                        return {
+                          datasetIndex: i,
+                          text: dataset.label,
+                          fillStyle: dataset.backgroundColor,
+                          hidden: isHidden,
+                          fontColor: isHidden ? 'rgba(128, 128, 128, 0.5)' : '#000000',
+                          fontStyle: isHidden ? 'normal' : 'bold',
+                          lineCap: 'butt',
+                          lineDash: [],
+                          lineDashOffset: 0,
+                          lineJoin: 'miter',
+                          strokeStyle: dataset.backgroundColor,
+                          pointStyle: 'rectRounded',
+                          rotation: 0,
+                          textDecoration: isHidden ? '' : 'none',
+                        };
+                      });
+                    }
+                  },                  
             },
             tooltip: {
                 mode: 'index' as const,
@@ -93,23 +97,31 @@ const HourlyVisitsChart: React.FC<HourlyVisitsChartProps> = ({ lastWeek, lastSix
         },
         scales: {
             x: {
-                ticks: {
-                    color: '#000',
-                    font: {
-                        size: 8,
-                    },
-                },
+              ticks: {
+                color: '#000',
+                font: { size: 8 },
+              },
+              title: {
+                display: true,
+                text: viewMode === 'raw' ? 'Visit Count' : 'Average Visits per Day',
+                color: '#000',
+                font: { size: 12, weight: 'bold' },
+              },
             },
             y: {
                 beginAtZero: true,
                 ticks: {
-                    color: '#000',
-                    font: {
-                        size: 10,
-                    },
+                  color: '#000',
+                  font: { size: 10 },
+                },
+                title: {
+                  display: true,
+                  text: viewMode === 'raw' ? 'Visit Count' : 'Average Visits per Day',
+                  color: '#000',
+                  font: { size: 12, weight: 'bold' },
                 },
             },
-        },
+        },          
     };
     
     return <Chart type="bar" data={data} options={options} />;

--- a/app/components/HourlyVisitsChart.tsx
+++ b/app/components/HourlyVisitsChart.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import {
+    Chart as ChartJS,
+    CategoryScale,
+    LinearScale,
+    BarElement,
+    PointElement,
+    LineElement,
+    Tooltip,
+    Legend,
+} from 'chart.js';
+
+import { Chart } from 'react-chartjs-2';
+
+ChartJS.register(
+    CategoryScale,
+    LinearScale,
+    BarElement,
+    PointElement,
+    LineElement,
+    Tooltip,
+    Legend
+);
+
+interface HourlyVisitsChartProps {
+    lastWeek: number[];
+    lastSixtyDays: number[];
+}
+
+
+const HourlyVisitsChart: React.FC<HourlyVisitsChartProps> = ({ lastWeek, lastSixtyDays }) => {
+    const labels = Array.from({ length: 24 }, (_, i) => `${i}:00`);
+
+    const data = {
+        labels,
+        datasets: [
+            {
+                type: 'line' as const,
+                label: 'Last 2 Months',
+                data: lastSixtyDays,
+                borderColor: '#24593D',
+                backgroundColor: '#24593D',
+                borderWidth: 2,
+                tension: 0.3,
+                fill: false,
+                pointRadius: 2,
+            },
+            {
+                type: 'bar' as const,
+                label: 'Last Week',
+                data: lastWeek,
+                backgroundColor: 'rgb(188, 215, 186)',
+                borderRadius: 5,
+            },
+        ],
+    };
+
+    const options = {
+        responsive: true,
+        plugins: {
+            legend: {
+                display: true,
+                position: 'top' as const,
+                labels: {
+                    boxWidth: 0,
+                    generateLabels: function(chart: any) {
+                        return chart.data.datasets.map((dataset: any, i: number) => {
+                            const meta = chart.getDatasetMeta(i);
+                            const fadedColor = 'rgba(128, 128, 128, 0.5)';
+                            const visibleColor = (i === 0)
+                            ? '#24593D'
+                            : 'rgb(137, 175, 132)';
+
+                            return {
+                                datasetIndex: i,
+                                text: (i === 0 ? dataset.label + '          ' : dataset.label),
+                                fillStyle: dataset.backgroundColor,
+                                hidden: meta.hidden,
+                                fontColor: meta.hidden ? fadedColor : visibleColor,
+                                textDecoration: 'none',
+                                fontStyle: 'normal',
+                                strokeStyle: null,
+                            };
+                        });
+                    },
+                },
+            },
+            tooltip: {
+                mode: 'index' as const,
+                intersect: false,
+            },
+        },
+        scales: {
+            x: {
+                ticks: {
+                    color: '#000',
+                    font: {
+                        size: 8,
+                    },
+                },
+            },
+            y: {
+                beginAtZero: true,
+                ticks: {
+                    color: '#000',
+                    font: {
+                        size: 10,
+                    },
+                },
+            },
+        },
+    };
+    
+    return <Chart type="bar" data={data} options={options} />;
+};
+
+export default HourlyVisitsChart;

--- a/app/customer-questions/[[...customer-questions]]/page.tsx
+++ b/app/customer-questions/[[...customer-questions]]/page.tsx
@@ -629,38 +629,6 @@ const Address: React.FC<AddressProps> = ({ line1, onAddressLineChange, setNextDi
             />
           </GeoapifyContext>
       </div>
-      <div className='flex flex-row w-2/3 justify-between gap-2'>
-        <div className='flex-1 mr-3'>
-          <p className="text-[24px] mt-4">{translations[2]} <span className="text-red">*</span></p>
-          <input
-            type="text"
-            className="bg-gray-50 border border-light-gray text-[24px] text-gray-900 rounded-lg focus:ring-blue-500 focus:border-blue-500 block p-2.5 w-full"
-            onChange={(e) => handleCityChange(e.target.value)}
-            value={cityState}
-            required
-          />
-        </div>
-        <div className='flex-1 mr-3'>
-          <p className="text-[24px] mt-4">{translations[3]} <span className="text-red">*</span></p>
-          <input
-            type="text"
-            className="bg-gray-50 border border-light-gray text-[24px] text-gray-900 rounded-lg focus:ring-blue-500 focus:border-blue-500 block p-2.5 w-full"
-            onChange={(e) => handleStateChange(e.target.value)}
-            value={stateState}
-            required
-          />
-        </div>
-        <div className='flex-1'>
-          <p className="text-[24px] mt-4">{translations[4]} <span className="text-red">*</span></p>
-          <input
-            type="text"
-            className="bg-gray-50 border border-light-gray text-[24px] text-gray-900 rounded-lg focus:ring-blue-500 focus:border-blue-500 block p-2.5 w-full"
-            onChange={(e) => handleZipChange(e.target.value)}
-            value={zipState}
-            required
-          />
-        </div>
-      </div>
 
       {/* timeout modal after 15 seconds of inactivity */}
       {showTimeoutModal &&

--- a/app/overview/[[...overview]]/page.tsx
+++ b/app/overview/[[...overview]]/page.tsx
@@ -65,14 +65,14 @@ const OverviewPage: React.FC = () => {
 
         setHouseSizeDistr(visitCountsArray);
 
-        let lastWeek = new Array(24).fill(0)
-        let lastSixtyDays = new Array(24).fill(0)
+        const lastWeek = new Array(24).fill(0)
+        const lastSixtyDays = new Array(24).fill(0)
 
-        let today = new Date();
-        let lastWeekDate = new Date(today);
+        const today = new Date();
+        const lastWeekDate = new Date(today);
         lastWeekDate.setDate(today.getDate() - 7);
 
-        let lastSixtyDaysDate = new Date(today);
+        const lastSixtyDaysDate = new Date(today);
         lastSixtyDaysDate.setDate(today.getDate() - 60);
 
         data.forEach((item) => {

--- a/app/overview/[[...overview]]/page.tsx
+++ b/app/overview/[[...overview]]/page.tsx
@@ -5,6 +5,7 @@ import { useUser } from "@clerk/nextjs";
 import type { UserResource } from "@clerk/types";
 import { Pie } from "react-chartjs-2";
 import { Chart as ChartJS, ArcElement, Tooltip, Legend } from "chart.js";
+import HourlyVisitsChart from '@app/components/HourlyVisitsChart';
 import LoadingAnimation from "@app/components/LoadingAnimation";
 
 ChartJS.register(ArcElement, Tooltip, Legend);
@@ -25,11 +26,13 @@ const OverviewPage: React.FC = () => {
   const isAuthorized = user && hasAccess(user);
 
   const [num_responses, setNumResponses] = useState<number | null>(null);
-  const [visitFrequencyData, setVisitFrequencyData] = useState<number[] | null>(null);
+  const [houseSizeDistr, setHouseSizeDistr] = useState<number[] | null>(null);
+  const [vistsLastWeek, setVisitsLastWeek] = useState<number[]>([]);
+  const [vistsLastSixtyDays, setVisitsLastSixtyDays] = useState<number[]>([]);
 
   const [isLoading12, setIsLoading12] = useState<boolean>(true);
   const [isLoading3, setIsLoading3] = useState<boolean>(false);
-  const [isLoading4, setIsLoading4] = useState<boolean>(false);
+  const [isLoading4, setIsLoading4] = useState<boolean>(true);
   const [isLoading5, setIsLoading5] = useState<boolean>(false);
   const [isLoading6, setIsLoading6] = useState<boolean>(false);
 
@@ -60,13 +63,37 @@ const OverviewPage: React.FC = () => {
           }
         });
 
-        setVisitFrequencyData(visitCountsArray);
+        setHouseSizeDistr(visitCountsArray);
+
+        let lastWeek = new Array(24).fill(0)
+        let lastSixtyDays = new Array(24).fill(0)
+
+        let today = new Date();
+        let lastWeekDate = new Date(today);
+        lastWeekDate.setDate(today.getDate() - 7);
+
+        let lastSixtyDaysDate = new Date(today);
+        lastSixtyDaysDate.setDate(today.getDate() - 60);
+
+        data.forEach((item) => {
+            const visitDate = new Date(item.lastVisitDate);
+            const hour = visitDate.getHours();
+
+            lastWeek[hour] += visitDate >= lastWeekDate ? 1/7 : 0;
+            lastSixtyDays[hour] += visitDate >= lastSixtyDaysDate ? 1/60 : 0;
+        })
+
+        setVisitsLastWeek(lastWeek);
+        setVisitsLastSixtyDays(lastSixtyDays);
+
+
       } catch (error) {
         console.error("Error fetching data:", error);
         setNumResponses(0);
-        setVisitFrequencyData(new Array(10).fill(0));
+        setHouseSizeDistr(new Array(10).fill(0));
       } finally {
         setIsLoading12(false);
+        setIsLoading4(false);
       }
     };
 
@@ -77,7 +104,7 @@ const OverviewPage: React.FC = () => {
     labels: ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10+"],
     datasets: [
       {
-        data: visitFrequencyData,
+        data: houseSizeDistr,
         backgroundColor: [
           "#3498DB", "#507c0c", "#24593D", "#EB2B0C", "#C31C01", "#3851BC",
           "#293b8b", "#828282", "#000000", "#ffe070"
@@ -127,7 +154,7 @@ const OverviewPage: React.FC = () => {
 
               {/* Household Size Pie Chart */}
               <div className="bg-white p-6 rounded-lg h-48 flex flex-col items-center justify-center shadow-md">
-                {isLoading12 || !visitFrequencyData ? (
+                {isLoading12 || !houseSizeDistr ? (
                   <div className="animate-spin rounded-full h-16 w-16 border-t-2 border-b-2 border-gray-600"></div>
                 ) : (
                   <>
@@ -164,13 +191,16 @@ const OverviewPage: React.FC = () => {
 
               {/* TBD Placeholder */}
               <div className="bg-white p-6 rounded-lg h-48 flex flex-col items-center justify-center shadow-md">
-                {isLoading4 ? (
+              {isLoading4 || !vistsLastWeek || !vistsLastSixtyDays ? (
                   <div className="animate-spin rounded-full h-16 w-16 border-t-2 border-b-2 border-gray-600"></div>
                 ) : (
-                  <>
-                    <div className="text-lg text-black font-crimson">TBD</div>
-                    <div className="text-3xl font-semibold font-crimson text-black mt-2">--</div>
-                  </>
+                    <>
+                        <div className="text-lg text-black font-crimson">Average Hourly Visits</div>
+                        {/* add temp border, make flex, center*/}
+                        <div className="w-full h-full flex justify-center">
+                            <HourlyVisitsChart lastWeek={vistsLastWeek} lastSixtyDays={vistsLastSixtyDays} />
+                        </div>
+                    </>
                 )}
               </div>
 

--- a/app/overview/[[...overview]]/page.tsx
+++ b/app/overview/[[...overview]]/page.tsx
@@ -29,6 +29,9 @@ const OverviewPage: React.FC = () => {
   const [houseSizeDistr, setHouseSizeDistr] = useState<number[] | null>(null);
   const [vistsLastWeek, setVisitsLastWeek] = useState<number[]>([]);
   const [vistsLastSixtyDays, setVisitsLastSixtyDays] = useState<number[]>([]);
+  const [rawVisitsLastWeek, setRawVisitsLastWeek] = useState<number[]>([]);
+  const [rawVisitsLastSixtyDays, setRawVisitsLastSixtyDays] = useState<number[]>([]);
+  const [viewMode, setViewMode] = useState<'average' | 'raw'>('raw');
 
   const [isLoading12, setIsLoading12] = useState<boolean>(true);
   const [isLoading3, setIsLoading3] = useState<boolean>(false);
@@ -65,26 +68,35 @@ const OverviewPage: React.FC = () => {
 
         setHouseSizeDistr(visitCountsArray);
 
-        const lastWeek = new Array(24).fill(0)
-        const lastSixtyDays = new Array(24).fill(0)
+        const avgLastWeek = new Array(24).fill(0);
+        const avgLastSixtyDays = new Array(24).fill(0);
+        const rawWeek = new Array(24).fill(0);
+        const rawSixty = new Array(24).fill(0);
 
         const today = new Date();
-        const lastWeekDate = new Date(today);
-        lastWeekDate.setDate(today.getDate() - 7);
-
-        const lastSixtyDaysDate = new Date(today);
-        lastSixtyDaysDate.setDate(today.getDate() - 60);
+        const weekAgo = new Date(today);
+        weekAgo.setDate(today.getDate() - 7);
+        const sixtyAgo = new Date(today);
+        sixtyAgo.setDate(today.getDate() - 60);
 
         data.forEach((item) => {
-            const visitDate = new Date(item.lastVisitDate);
-            const hour = visitDate.getHours();
+          const visitDate = new Date(item.lastVisitDate);
+          const hour = visitDate.getHours();
 
-            lastWeek[hour] += visitDate >= lastWeekDate ? 1/7 : 0;
-            lastSixtyDays[hour] += visitDate >= lastSixtyDaysDate ? 1/60 : 0;
-        })
+          if (visitDate >= weekAgo) {
+            rawWeek[hour] += 1;
+            avgLastWeek[hour] += 1 / 7;
+          }
+          if (visitDate >= sixtyAgo) {
+            rawSixty[hour] += 1;
+            avgLastSixtyDays[hour] += 1 / 60;
+          }
+        });
 
-        setVisitsLastWeek(lastWeek);
-        setVisitsLastSixtyDays(lastSixtyDays);
+        setRawVisitsLastWeek(rawWeek);
+        setRawVisitsLastSixtyDays(rawSixty);
+        setVisitsLastWeek(avgLastWeek);
+        setVisitsLastSixtyDays(avgLastSixtyDays);
 
 
       } catch (error) {
@@ -189,18 +201,42 @@ const OverviewPage: React.FC = () => {
                 )}
               </div>
 
-              {/* TBD Placeholder */}
-              <div className="bg-white p-6 rounded-lg h-48 flex flex-col items-center justify-center shadow-md">
-              {isLoading4 || !vistsLastWeek || !vistsLastSixtyDays ? (
+              {/* Average Visits per week and last 60 days */}
+              <div className="bg-white p-6 rounded-lg h-80 flex flex-col items-center justify-center shadow-md">
+                {isLoading4 || !vistsLastWeek || !vistsLastSixtyDays ? (
                   <div className="animate-spin rounded-full h-16 w-16 border-t-2 border-b-2 border-gray-600"></div>
                 ) : (
-                    <>
-                        <div className="text-lg text-black font-crimson">Average Hourly Visits</div>
-                        {/* add temp border, make flex, center*/}
-                        <div className="w-full h-full flex justify-center">
-                            <HourlyVisitsChart lastWeek={vistsLastWeek} lastSixtyDays={vistsLastSixtyDays} />
-                        </div>
-                    </>
+                  <>
+                    <div className="text-lg text-black font-crimson">Hourly Visit Stats</div>
+
+                    {/* toggle buttons for raw visits and average visits */}
+                    <div className="flex justify-center space-x-4 mb-2 pt-4">
+                      <button
+                        className={`px-3 py-1 rounded-full font-semibold ${
+                          viewMode === 'raw' ? 'bg-dark-green text-white' : 'bg-gray-200 text-black'
+                        }`}
+                        onClick={() => setViewMode('raw')}
+                      >
+                        Raw Count
+                      </button>
+                      <button
+                        className={`px-3 py-1 rounded-full font-semibold ${
+                          viewMode === 'average' ? 'bg-dark-green text-white' : 'bg-gray-200 text-black'
+                        }`}
+                        onClick={() => setViewMode('average')}
+                      >
+                        Average
+                      </button>
+                    </div>
+
+                    <div className="w-full h-full flex justify-center">
+                      <HourlyVisitsChart
+                        lastWeek={viewMode === 'average' ? vistsLastWeek : rawVisitsLastWeek}
+                        lastSixtyDays={viewMode === 'average' ? vistsLastSixtyDays : rawVisitsLastSixtyDays}
+                        viewMode={viewMode}
+                      />
+                    </div>
+                  </>
                 )}
               </div>
 


### PR DESCRIPTION
**Ticket Number:** 281
**Name:** Charlie
**Purpose:** Added chart to overview to show hourly visits for the last week and the last 60 days
**Time:** 3 hours
**Takeaways:** Chart js is really easy to start but not fun to customize. I'd like to learn more about plugins

**Testing:**

<img width="438" alt="Screenshot 2025-04-13 at 8 40 39 PM" src="https://github.com/user-attachments/assets/9c8a6d99-1569-4ed9-a89b-404b64a2f1f3" />
<img width="434" alt="Screenshot 2025-04-13 at 8 41 07 PM" src="https://github.com/user-attachments/assets/991a20ee-6c1a-4b07-b59d-fd35977e4206" />
<img width="442" alt="Screenshot 2025-04-13 at 8 40 50 PM" src="https://github.com/user-attachments/assets/7ca3a561-e69a-44cf-a5a2-2cc704e68c5e" />
<img width="438" alt="Screenshot 2025-04-13 at 8 40 44 PM" src="https://github.com/user-attachments/assets/96965604-e9d2-41ca-82c9-1619103e2356" />